### PR TITLE
Adds an Ignore option for Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To help in these scenarios there are the following options to be used when calcu
 - `IgnoreStatusFields`
 - `IgnoreVolumeClaimTemplateTypeMetaAndStatus`
 - `IgnorePDBSelector`
-- `IgnoreMetaDataFields`
+- `IgnoreField("field-name-to-ignore")`
 
 Example:
 ```
@@ -92,9 +92,10 @@ This CalculateOption clears volumeClaimTemplate fields from both objects before 
 Checks `selector` fields of PDB objects before comparing and removes them if they match. `reflect.DeepEquals` is used for the equality check. 
 This is required because map fields using `patchStrategy:"replace"` will always diff regardless if they are otherwise equal.
 
-#### IgnoreMetaDataFields
+#### IgnoreField("field-name-to-ignore")
 
-This CalculateOptions removes metadata fields from both objects before comparing. It is useful if you only want differences in the Spec field.
+This CalculateOption removes the field provided (as a string) in the call before comparing them. A common usage might be to remove the metadata fields by using the `IgnoreField("metadata")` option.
+
 
 ## Contributing
 

--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -41,16 +41,16 @@ func IgnoreStatusFields() CalculateOption {
 	}
 }
 
-func IgnoreMetaDataFields() CalculateOption {
+func IgnoreField(field string) CalculateOption {
 	return func(current, modified []byte) ([]byte, []byte, error) {
-		current, err := deleteMetaDataField(current)
+		current, err := deleteDataField(current, field)
 		if err != nil {
-			return []byte{}, []byte{}, errors.Wrap(err, "could not delete status field from current byte sequence")
+			return []byte{}, []byte{}, errors.Wrap(err, "could not delete the field from current byte sequence")
 		}
 
-		modified, err = deleteMetaDataField(modified)
+		modified, err = deleteDataField(modified, field)
 		if err != nil {
-			return []byte{}, []byte{}, errors.Wrap(err, "could not delete status field from modified byte sequence")
+			return []byte{}, []byte{}, errors.Wrap(err, "could not delete the field from modified byte sequence")
 		}
 
 		return current, modified, nil
@@ -189,13 +189,13 @@ func deleteNullInSlice(m []interface{}) ([]interface{}, error) {
 	return filteredSlice, nil
 }
 
-func deleteMetaDataField(obj []byte) ([]byte, error) {
+func deleteDataField(obj []byte, fieldName string) ([]byte, error) {
 	var objectMap map[string]interface{}
 	err := json.Unmarshal(obj, &objectMap)
 	if err != nil {
 		return []byte{}, errors.Wrap(err, "could not unmarshal byte sequence")
 	}
-	delete(objectMap, "metadata")
+	delete(objectMap, fieldName)
 	obj, err = json.ConfigCompatibleWithStandardLibrary.Marshal(objectMap)
 	if err != nil {
 		return []byte{}, errors.Wrap(err, "could not marshal byte sequence")

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -186,13 +186,14 @@ func (t *TestItem) withIgnoreVersions(v []string) *TestItem {
 	return t
 }
 
-func testMatchOnObject(testItem *TestItem) error {
+func testMatchOnObject(testItem *TestItem, ignoreField string) error {
 	var existing metav1.Object
 	var err error
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		patch.IgnorePDBSelector(),
+		patch.IgnoreField(ignoreField),
 	}
 
 	newObject := testItem.object


### PR DESCRIPTION
This change adds an Ignore option for the
metadata field.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Adds an IgnoreCalculation option to ignore the metadata field. 


### Why?
Feature enhancement.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
