### PR TITLE
Use Go v1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cisco-open/k8s-objectmatcher
 
-go 1.22.0
+go 1.22
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
## Description
Go modules that are defined with `go 1.22` are not compatible, because the minimum version is set to `go 1.22.0`. This PR will reset it back to just `1.22` to fix these compatibility issues.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
